### PR TITLE
Proprely handle errors with drizzle-otel

### DIFF
--- a/packages/otel-drizzle/package.json
+++ b/packages/otel-drizzle/package.json
@@ -41,7 +41,7 @@
     "@opentelemetry/sdk-trace-base": "^2.1.0",
     "@types/node": "18.15.11",
     "@types/pg": "^8.11.10",
-    "drizzle-orm": "^0.36.4",
+    "drizzle-orm": "^0.44.7",
     "postgres": "^3.4.7",
     "rimraf": "3.0.2",
     "typescript": "^5",

--- a/packages/otel-drizzle/src/index.ts
+++ b/packages/otel-drizzle/src/index.ts
@@ -5,6 +5,7 @@ import {
   trace,
   type Span,
 } from "@opentelemetry/api";
+import { DrizzleQueryError } from "drizzle-orm";
 
 const DEFAULT_TRACER_NAME = "@kubiks/otel-drizzle";
 const DEFAULT_DB_SYSTEM = "postgresql";
@@ -130,7 +131,12 @@ function extractOperation(queryText: string): string | undefined {
  */
 function finalizeSpan(span: Span, error?: unknown): void {
   if (error) {
-    if (error instanceof Error) {
+    if (error instanceof DrizzleQueryError && error.cause) {
+      // special handling for node-postgres
+      if ("detail" in error.cause && typeof error.cause.detail === "string")
+        error.cause.stack = error.cause.detail;
+      span.recordException(error.cause)
+    } else if (error instanceof Error) {
       span.recordException(error);
     } else {
       span.recordException(new Error(String(error)));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,8 +111,8 @@ importers:
         specifier: ^8.11.10
         version: 8.15.5
       drizzle-orm:
-        specifier: ^0.36.4
-        version: 0.36.4(@opentelemetry/api@1.9.0)(@types/pg@8.15.5)(@types/react@18.2.46)(kysely@0.28.7)(postgres@3.4.7)(react@18.2.0)
+        specifier: ^0.44.7
+        version: 0.44.7(@opentelemetry/api@1.9.0)(@types/pg@8.15.5)(kysely@0.28.7)(postgres@3.4.7)
       postgres:
         specifier: ^3.4.7
         version: 3.4.7
@@ -953,15 +953,6 @@ packages:
   '@types/pg@8.15.5':
     resolution: {integrity: sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ==}
 
-  '@types/prop-types@15.7.11':
-    resolution: {integrity: sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==}
-
-  '@types/react@18.2.46':
-    resolution: {integrity: sha512-nNCvVBcZlvX4NU1nRRNV/mFl1nNRuTuslAJglQsq+8ldXe5Xv0Wd2f7WTE3jOxhLH2BFfiZGC6GCp+kHQbgG+w==}
-
-  '@types/scheduler@0.16.8':
-    resolution: {integrity: sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==}
-
   '@types/semver@7.5.6':
     resolution: {integrity: sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==}
 
@@ -1270,9 +1261,6 @@ packages:
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
 
-  csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
-
   csv-generate@3.4.3:
     resolution: {integrity: sha512-w/T+rqR0vwvHqWs/1ZyMDWtHHSJaN06klRqJXBEpDJaM/+dZkso0OKh1VcuuYvK3XM53KysVNq8Ko/epCK8wOw==}
 
@@ -1371,36 +1359,36 @@ packages:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
     engines: {node: '>=10'}
 
-  drizzle-orm@0.36.4:
-    resolution: {integrity: sha512-1OZY3PXD7BR00Gl61UUOFihslDldfH4NFRH2MbP54Yxi0G/PKn4HfO65JYZ7c16DeP3SpM3Aw+VXVG9j6CRSXA==}
+  drizzle-orm@0.44.7:
+    resolution: {integrity: sha512-quIpnYznjU9lHshEOAYLoZ9s3jweleHlZIAWR/jX9gAWNg/JhQ1wj0KGRf7/Zm+obRrYd9GjPVJg790QY9N5AQ==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
-      '@cloudflare/workers-types': '>=3'
+      '@cloudflare/workers-types': '>=4'
       '@electric-sql/pglite': '>=0.2.0'
       '@libsql/client': '>=0.10.0'
       '@libsql/client-wasm': '>=0.10.0'
       '@neondatabase/serverless': '>=0.10.0'
       '@op-engineering/op-sqlite': '>=2'
       '@opentelemetry/api': ^1.4.1
-      '@planetscale/database': '>=1'
+      '@planetscale/database': '>=1.13'
       '@prisma/client': '*'
       '@tidbcloud/serverless': '*'
       '@types/better-sqlite3': '*'
       '@types/pg': '*'
-      '@types/react': '>=18'
       '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
       '@vercel/postgres': '>=0.8.0'
       '@xata.io/client': '*'
       better-sqlite3: '>=7'
       bun-types: '*'
       expo-sqlite: '>=14.0.0'
+      gel: '>=2'
       knex: '*'
       kysely: '*'
       mysql2: '>=2'
       pg: '>=8'
       postgres: '>=3'
       prisma: '*'
-      react: '>=18'
       sql.js: '>=1'
       sqlite3: '>=5'
     peerDependenciesMeta:
@@ -1430,9 +1418,9 @@ packages:
         optional: true
       '@types/pg':
         optional: true
-      '@types/react':
-        optional: true
       '@types/sql.js':
+        optional: true
+      '@upstash/redis':
         optional: true
       '@vercel/postgres':
         optional: true
@@ -1443,6 +1431,8 @@ packages:
       bun-types:
         optional: true
       expo-sqlite:
+        optional: true
+      gel:
         optional: true
       knex:
         optional: true
@@ -1455,8 +1445,6 @@ packages:
       postgres:
         optional: true
       prisma:
-        optional: true
-      react:
         optional: true
       sql.js:
         optional: true
@@ -3599,19 +3587,6 @@ snapshots:
       pg-protocol: 1.10.3
       pg-types: 2.2.0
 
-  '@types/prop-types@15.7.11':
-    optional: true
-
-  '@types/react@18.2.46':
-    dependencies:
-      '@types/prop-types': 15.7.11
-      '@types/scheduler': 0.16.8
-      csstype: 3.1.3
-    optional: true
-
-  '@types/scheduler@0.16.8':
-    optional: true
-
   '@types/semver@7.5.6': {}
 
   '@types/webidl-conversions@7.0.3': {}
@@ -3936,9 +3911,6 @@ snapshots:
 
   crypto-js@4.2.0: {}
 
-  csstype@3.1.3:
-    optional: true
-
   csv-generate@3.4.3: {}
 
   csv-parse@4.16.3: {}
@@ -4028,14 +4000,12 @@ snapshots:
 
   dotenv@8.6.0: {}
 
-  drizzle-orm@0.36.4(@opentelemetry/api@1.9.0)(@types/pg@8.15.5)(@types/react@18.2.46)(kysely@0.28.7)(postgres@3.4.7)(react@18.2.0):
+  drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/pg@8.15.5)(kysely@0.28.7)(postgres@3.4.7):
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/pg': 8.15.5
-      '@types/react': 18.2.46
       kysely: 0.28.7
       postgres: 3.4.7
-      react: 18.2.0
 
   e2b@2.6.2:
     dependencies:


### PR DESCRIPTION
Drizzle doesn't properly handle errors, and only wraps the driver's error exception.
Here's an example of their error handling:
```ts
try {
    return await query();
}
catch (e) {
    throw new DrizzleQueryError(queryString, params, e as Error);
}
```

This means the current otel code doesn't report the correct logs, and only shows the querystring & params.

You can have more background here: https://github.com/drizzle-team/drizzle-orm/discussions/916#discussioncomment-14245668 & the proper tracking issue is: https://github.com/drizzle-team/drizzle-orm/issues/376

Here's an example of exception i got with node-postgres:
```json
{
	"query":"insert into [...]",

	"params":[
		72,
		{"serie":{"slug":"psycho-pass"},"special":12},
	],
	"cause":{
		"length":319,
		"name":"error",
		"severity":"ERROR",
		"code":"23505",
		"detail":"Key (slug)=(psyoch-pass) already exists.",
		"schema":"kyoo",
		"table":"entry_video_join",
		"constraint":"entry_video_join_slug_unique",
		"file":"nbtinsert.c",
		"routine":"_bt_check_unique",
		"stack":"error: duplicate key value violates unique constraint \"entry_video_join_slug_unique\"\n    at <anonymous> (/app/node_modules/pg/lib/client.js:545:17)\n    at processTicksAndRejections (native:7:39)"
	}
}
```

after checking, `e.cause.message` contains `error: duplicate key value violates unique constraint \"entry_video_join_slug_unique\"` so i figured it make more sense to also include `detail` instead of `stack` again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated drizzle-orm dependency to a newer version

* **Bug Fixes**
  * Improved error handling and reporting for database query errors with better context and detail propagation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->