### PR TITLE
Adds Middleware in OTel Supported Platforms List

### DIFF
--- a/packages/otel-clickhouse/README.md
+++ b/packages/otel-clickhouse/README.md
@@ -47,6 +47,7 @@ Works with any observability platform that supports OpenTelemetry including:
 - [Sentry](https://sentry.io)
 - [Axiom](https://axiom.co)
 - [Datadog](https://www.datadoghq.com)
+- [Middleware](https://middleware.io/)
 - [New Relic](https://newrelic.com)
 - [SigNoz](https://signoz.io)
 - And others ...


### PR DESCRIPTION
Add middleware.io in the supported platforms as it has OTel support.